### PR TITLE
chore: pin actions and images to SHA digests

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,8 +10,8 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-node@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: "24"
           registry-url: "https://registry.npmjs.org"


### PR DESCRIPTION
## Summary

Pins all mutable GitHub Actions references to immutable SHA digests for supply chain security and reproducibility.

| Metric | Count |
|---|---|
| Files scanned | 1 (`.github/workflows/publish.yml`) |
| References found | 2 |
| Newly pinned | 2 |
| Already pinned (skipped) | 0 |
| Failed to resolve | 0 |
| Transitive upgrades | 0 |

### Changes
- `actions/checkout@v5` → `actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1`
- `actions/setup-node@v5` → `actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0`

Both are Node.js JavaScript actions with no transitive `uses:` dependencies. No Dockerfiles or composite actions were present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)